### PR TITLE
Week2 박준영 14888 연산자 끼워넣기 ( next_permutation ) 풀이

### DIFF
--- a/src/week2/operatorInsert14888/Main.java
+++ b/src/week2/operatorInsert14888/Main.java
@@ -1,4 +1,128 @@
 package week2.operatorInsert14888;
 
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/*
+ * 시간 제한 : 2초 메모리 : 128MB
+ * N : 숫자의 갯수 1 <= N <= 11
+ * Ai : 숫자의 범위 1 <= Ai <= 100
+ * */
 public class Main {
+
+    private static int n, max, min;                 // 피연산자 수, 최댓값, 최솟값
+    private static String[] operand;      // 피연산자
+    private static List<Character> operators = new ArrayList<>();       // 연산자
+
+    public static void main(String[] args) throws IOException {
+
+        FileInputStream file = new FileInputStream("./algorithm_java/res/baekjoon/operator_insert_input.txt");
+        BufferedReader in = new BufferedReader(new InputStreamReader(file));
+//        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        long start = System.nanoTime();
+
+        n = Integer.parseInt(in.readLine());            // 숫자의 갯수
+        // n개의 숫자 할당
+        operand = new String[n];
+        StringTokenizer st = new StringTokenizer(in.readLine());
+        max = Integer.MIN_VALUE;
+        min = Integer.MAX_VALUE;
+
+        for(int i = 0; i < n; i++) {
+            operand[i] = st.nextToken().trim();
+        }
+
+        // 사용가능한 연산자 갯수 할당
+        st = new StringTokenizer(in.readLine());
+        getOperator('+',Integer.parseInt(st.nextToken()));
+        getOperator('-',Integer.parseInt(st.nextToken()));
+        getOperator('*',Integer.parseInt(st.nextToken()));
+        getOperator('/',Integer.parseInt(st.nextToken()));
+
+        Collections.sort(operators);
+        do{
+            expression();
+        } while(np());
+
+        sb.append(max).append("\n").append(min);
+        System.out.println(sb);
+
+        long end = System.nanoTime();
+        System.out.println((end - start) / 1000000 +"s");
+        in.close();
+
+    }
+
+    private static boolean np() {
+
+        int i = n - 2;
+        while ( i > 0 && operators.get(i-1) >= operators.get(i) ) --i;
+
+        if( i == 0 ) return false;
+
+        int j = n - 2;
+        while ( operators.get(i-1) >= operators.get(j)) --j;
+
+        swap(i -1, j);
+
+        int k = n - 2;
+        while ( i < k) swap(i++,k--);
+
+        return true;
+    }
+
+    private static void swap(int i, int j) {
+        char tmp = operators.get(i);
+        operators.set(i,operators.get(j));
+        operators.set(j,tmp);
+    }
+    private static void expression() {
+        int result = 0;
+        Queue<String> q = new LinkedList<>();
+        for(int i = 0; i < n - 1;i++ ) {
+            q.offer(operand[i]);
+            q.offer(String.valueOf(operators.get(i)));
+        }
+        q.offer(operand[n-1]);
+        result = Integer.parseInt(q.poll());
+        while ( !q.isEmpty() ) {
+            String oper = q.poll();
+            int op2 = Integer.parseInt(q.poll());
+            result = getOperater(result,op2,oper);
+        }
+        if( max < result) max = result;
+        if( min > result) min = result;
+    }
+
+    private static int getOperater(int op1 , int op2, String operator) {
+        switch ( operator ) {
+            case "+":
+                return op1 + op2;
+            case "-":
+                return op1 - op2;
+            case "*":
+                return op1 * op2;
+            case "/":
+                int result = 0;
+                if( op1 < 0) {
+                    op1 = -op1;
+                    result = -(op1 / op2);
+                    return result;
+                }
+                result = (op1 / op2);
+                return result;
+            default:
+                return 0;
+        }
+    }
+
+    private static void getOperator(char order, int count) {
+        for(int i = 0; i < count; i++) {
+            operators.add(order);
+        }
+    }
 }


### PR DESCRIPTION
# 🥈 실버1 - 연산자 끼워넣기

## 풀이 방법

— 순열문제 라는 것을 인식

— 처음에는 피연산자와 연산자로 순열을 만들어서 처리를 하려고 하였지만..

— 피연산자는 고정되어 있기 때문에 필요성이 없다는 것을 인식

방법.1 모든 연산자와 피연산자를 Stack에 저장해서 역으로 출력하는 방법을 생각

- top부터 3개의 데이터를 꺼내온다. ( operand1, operator, operand2)
- 연산해서 나온 결과를 다시 stack에 넣어준다.
- 최종적으로 stack에 데이터가 1개 남을 때까지 계속 반복한다.

결과 ⇒ 시간초과

Stack에서 빼고, 넣는데 시간이 추가적으로 발생하기 때문에 stack이 아닌 Queue를 이용해봄

방법.2 모든 연산자와 피연산자를 Queue에 저장해서 순서대로 빼서 연산을 한다.

- 피연산자 index(1)은 먼저 Queue에 저장하고
- Queue에서 2개씩 빼서 연산을 반복적으로 하고
- Queue가 빈상태면 최솟값인지 확인

결과 ⇒ 맞았습니다. But 메모리와 시간이 최악!!!

방법.3 연산자만 NP를 이용해서 순서를 재정렬하여 연산을 수행하도록 처리

- 재귀를 이용해서 피연산자를 넣는부분을 없애고
- NP를 활용해서 do - while 돌리고 더 이상 조합이 없을 때까지 반복
- 수행할때마다 나온 조합을 연산을 수행하고 최솟값을 검증(Math.min)

결과 ⇒ 맞습니다.  and 메모리와 시간이 압도적으로 줄어든것을 확인

## 리뷰 사항

- 재귀와 NP를 비교하면서 확인해주었으면 좋겠습니다.

## 느낀점

- 너무 문제를 어렵게 생각하는 경향이 있는 것 같다.
- NP의 우월함을 느끼는 순간이였습니다.