### PR TITLE
Week2 함시연 1931 회의실배정 풀이

### DIFF
--- a/src/week2/meetingRoomAssignment1931/Main.java
+++ b/src/week2/meetingRoomAssignment1931/Main.java
@@ -1,4 +1,44 @@
-package week2.meetingRoomAssignment1931;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
 
 public class Main {
+    static class meeting implements Comparable<meeting>{	//처음과 시작을 저장하는 객체
+        int start;
+        int end;
+        public meeting(int start, int end){
+            this.start = start;
+            this.end = end;
+        }
+        @Override
+        public int compareTo(meeting o) {	//끝나는 시간으로 정렬, 끝나는 시간 같을 시 시작시간으로 정렬
+            if(this.end==o.end) return this.start-o.start;
+            return this.end-o.end;
+            
+        }
+    }
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        meeting[] arr = new meeting[N];
+        StringTokenizer st;
+        for(int i=0; i<N; i++){
+            st = new StringTokenizer(br.readLine());
+            arr[i] = new meeting(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));
+        }
+        Arrays.sort(arr);
+        int count=1;
+        meeting now = arr[0];
+        for(int i=1; i<arr.length; i++){	//객체 배열의 맨 앞부터 끝나는 시간과 시작하는 시간을 비교하며 카운트
+            if(now.end<=arr[i].start){
+                count++;
+                now = arr[i];
+                continue;
+            }
+        }
+        
+        System.out.println(count);
+
+    }
 }


### PR DESCRIPTION
##풀이방법
처음 완전탐색으로 풀었다가 시간 초과가 나서 그리디하게 풀어야함을 알았습니다. 많은 회의실을 배정하려면 시작시간과 끝나는 시간의 텀이 짧은 회의를 여러개 넣어야하고, 그렇게 하려면 우선 끝나는 시간을 기준으로 정렬해야함을 알았습니다. 객체를 만들어 시작 시간과 끝나는 시간을 저장했고, 끝나는 시간을 기준으로 정렬했습니다. 이후 끝나는 시간과 시작시간이 겹치지 않는 선에서 회의를 선택하며 카운트를 증가시켰습니다.
##리뷰요청사항

##느낀점
문제를 풀 때 기준점을 찾는 게(여기서는 종료시간) 상당히 헷갈렸습니다.