### PR TITLE
Week4 서영탁 17070 파이프옮기기1 풀이 by DFS

### DIFF
--- a/src/week4/movePipe17070/Main.java
+++ b/src/week4/movePipe17070/Main.java
@@ -1,4 +1,69 @@
 package week4.movePipe17070;
 
+import java.io.*;
+import java.util.*;
+
 public class Main {
+
+    public static int n, ans;
+    public static int[][] map;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        map = new int[n+1][n+1];
+
+        for(int i = 1; i <= n; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j <= n; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        pipeline(0, 1, 2);
+        System.out.println(ans);
+    }
+
+    public static void pipeline(int shape, int x, int y){
+        if(x == n && y == n){
+            ans++;
+            return;
+        }
+
+        if(shape == 0){
+            if(checkRight(x, y)) pipeline(0, x, y+1);
+            if(checkCross(x, y)) pipeline(2, x+1, y+1);
+        }
+        else if(shape == 1){
+            if(checkDown(x, y)) pipeline(1, x+1, y);
+            if(checkCross(x, y)) pipeline(2, x+1, y+1);
+        }
+        else{
+            if(checkRight(x, y)) pipeline(0, x, y+1);
+            if(checkDown(x, y)) pipeline(1, x+1, y);
+            if(checkCross(x, y)) pipeline(2, x+1, y+1);
+        }
+    }
+
+    public static boolean checkRight(int x, int y){
+        if(!isRange(x, y+1)) return false;
+        return map[x][y+1] == 0;
+    }
+
+    public static boolean checkDown(int x, int y){
+        if(!isRange(x+1, y)) return false;
+        return map[x+1][y] == 0;
+    }
+
+    public static boolean checkCross(int x, int y){
+        if(!isRange(x+1, y+1) || !checkRight(x, y) || !checkDown(x, y)) return false;
+        return map[x+1][y+1] == 0;
+    }
+
+    public static boolean isRange(int x, int y){
+        return x > 0 && x <= n && y > 0 && y <= n;
+    }
+
 }


### PR DESCRIPTION
## 풀이
우선 dfs를 이용하여 풀었습니다.
시작점을 (1,2)로 설정하여 조건에 맞게 움직여 (n,n)으로 갈 수 있는 개수를 계산하였습니다.
`public static void pipeline(int shape, int x, int y)`에서 `shape`는 파이프의 모양으로 0이면 가로, 1이면 세로, 2이면 대각선으로 설정하였습니다.
가로 상태에서는 가로와 대각선, 세로 상태에서는 세로와 대각선, 대각선 상태에서는 가로, 세로, 대각선 모두 갈 수 있기 때문에 움직일 때 벽이 없다면 dfs를 더 탐색할 수 있도록 했습니다.

## 느낀점
dfs로 풀고 나서 dp로 풀면 dfs의 재귀를 덜 돌리고 빠르게 풀 수 있겠다라고 생각되어 dp로도 풀어봤습니다.