### PR TITLE
Week4 서영탁 17070 파이프옮기기1 풀이 by DP

### DIFF
--- a/src/week4/movePipe17070/Main.java
+++ b/src/week4/movePipe17070/Main.java
@@ -1,4 +1,54 @@
 package week4.movePipe17070;
 
+import java.io.*;
+import java.util.*;
+
 public class Main {
+
+    public static int n;
+    public static int[][] map;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        map = new int[n+1][n+1];
+
+        for(int i = 1; i <= n; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j <= n; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int[][][] dp = new int[n+1][n+1][3];
+        dp[1][2][0] = 1;
+
+        for(int i = 1; i <= n; i++){
+            for(int j = 3; j <= n; j++){
+                if(map[i][j] == 0) {
+                    if (checkLeft(i, j)) dp[i][j][0] = dp[i][j - 1][0] + dp[i][j - 1][2];
+                    if (checkUp(i, j)) dp[i][j][1] = dp[i - 1][j][1] + dp[i - 1][j][2];
+                    if (checkCross(i, j)) dp[i][j][2] = dp[i - 1][j - 1][0] + dp[i - 1][j - 1][1] + dp[i - 1][j - 1][2];
+                }
+            }
+        }
+
+        int ans = dp[n][n][0] + dp[n][n][1] + dp[n][n][2];
+        System.out.println(ans);
+    }
+
+    public static boolean checkLeft(int x, int y){
+        return y-1 > 0;
+    }
+
+    public static boolean checkUp(int x, int y){
+        return x-1 > 0;
+    }
+
+    public static boolean checkCross(int x, int y){
+        return checkLeft(x,y) && checkUp(x,y) && map[x][y-1] == 0 && map[x-1][y] == 0;
+    }
+
 }


### PR DESCRIPTION
## 풀이
이번에는 dp로 풀어보았습니다.
`int[][][] dp = new int[n+1][n+1][3]`으로 dp배열을 생성하였습니다.
`dp[x][y][dir]`에서 x와 y는 좌표이고, dir은 파이프의 상태입니다. 
여기서도 파이프가 가로이면 dir = 0, 세로이면 dir = 1, 대각선이면 dir = 2로 설정하였습니다.
그리고 `dp[x][y][dir]`의 값은 현재 (x,y)에 dir 방향으로 올 수 있는 모든 경우의 수를 의미합니다.
  
  

![IMG_FDE4930988EA-1](https://user-images.githubusercontent.com/89503136/187057149-28c2331b-7c2a-41b4-8f53-97e11deaa614.jpeg)
`dp[3][5][0]`이 가능한 경우는 `dp[3][4][0]` +  `dp[3][4][2]`와 같습니다.
![IMG_02994FEC91B9-1](https://user-images.githubusercontent.com/89503136/187057194-5a1ba103-c209-4aee-8cb7-653e72310c5c.jpeg)
![IMG_D134B22E79EA-1](https://user-images.githubusercontent.com/89503136/187057208-f52b0385-45c7-4f5d-9130-76539c503543.jpeg)  
  
따라서 세로와 대각선도 이런 식으로 누적하여 마지막 (n,n)에 도달하는 가로, 세로, 대각선을 모두 더해주면, 
`dp[n][n][0]`+`dp[n][n][1]`+`dp[n][n][2]` 답이됩니다.

```
for(int i = 1; i <= n; i++){
            for(int j = 3; j <= n; j++){
                if(map[i][j] == 0) {
                    if (checkLeft(i, j)) dp[i][j][0] = dp[i][j - 1][0] + dp[i][j - 1][2];
                    if (checkUp(i, j)) dp[i][j][1] = dp[i - 1][j][1] + dp[i - 1][j][2];
                    if (checkCross(i, j)) dp[i][j][2] = dp[i - 1][j - 1][0] + dp[i - 1][j - 1][1] + dp[i - 1][j - 1][2];
                }
            }
        }
```
또한 여기서 j를 3부터 보는 이유는 파이프가 오른쪽으로만 갈 수 있기 때문에 1,2를 볼 필요가 없기 때문입니다.

## 리뷰 요청 사항
그림은 가로인 경우만 그렸습니다. ㅎㅎ
이해되지 않는 점이 있다면 리뷰달아주세요.

## 느낀점
dp는 여전히 어렵습니다.