### PR TITLE
김명진  1092 배풀이

### DIFF
--- a/src/week5/ship1092/Main.java
+++ b/src/week5/ship1092/Main.java
@@ -1,4 +1,62 @@
 package week5.ship1092;
 
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+
 public class Main {
+    static int N;
+    static int M;
+    static Stack<Integer> originCraneStack;
+    static int time = 0;
+    public static void main(String[] args) throws IOException {
+        //System.setIn(new FileInputStream("resources/study/week5/BJ1092/input5.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        originCraneStack = new Stack<>();
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        ArrayList<Integer> tempCranes = new ArrayList<>();
+        for (int n = 0; n < N; n++) {
+            tempCranes.add(Integer.parseInt(st.nextToken()));
+        }
+        ArrayList<Integer> tempCargos = new ArrayList<>();
+        M = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+        for (int m = 0; m < M; m++) {
+            tempCargos.add(Integer.parseInt(st.nextToken()));
+        }
+        Collections.sort(tempCranes);
+        Collections.sort(tempCargos, new Comparator<Integer>() {
+            @Override
+            public int compare(Integer o1, Integer o2) {
+                return o2.compareTo(o1);
+            }
+        });
+        for(Integer el :tempCranes){
+            originCraneStack.push(el);
+        }
+
+        if(Collections.max(originCraneStack) < Collections.max(tempCargos)){
+            System.out.println(-1);
+            System.exit(0);
+        }
+        while (!tempCargos.isEmpty()){
+            Stack<Integer> roundStack = (Stack<Integer>) originCraneStack.clone();
+            time++;
+            while (!roundStack.isEmpty()){
+                int currCrane = roundStack.pop();
+                for(int i = 0, size = tempCargos.size(); i < size; i++){
+                    if(currCrane >= tempCargos.get(i)){
+                        tempCargos.remove(i);
+                        break;
+                    }
+                }
+            }
+        }
+        System.out.println(time);
+
+    }
 }


### PR DESCRIPTION
## 풀이
* 공간/ 시간	17828kb	4964ms
* 화물과 크레인을 내림차순으로 정렬해 큰거 먼저 처리하는 형태로 접근했습니다
* 크래인은 stack으로 O(1)의연산을 가지지만
* 화물의 경우 내림차순으로 정렬해도 바로 stack 에서 크레인 무게 한계보다
* 화물이 더큰 경우가 있기에 for 를 쓸수 밖에 없었습니다 ex) 크래인 20 20 18 화물 20 20 20 20 20 20 일때

## 리뷰 요청 사항
* 여러분들 풀이보다 시간이 복잡도가 큰거 같은데 어느부분을 고쳐야 할지 모르겠습니다 ㅜ 혹시 알려주실수 있을까요?
## 느낀점
*   처음에 삭제 비용이 좋은 링크드 리스트를 화물에 적용 했지만 결국 삭제 보다 순회를 자주 하는 제 코드에서 시간이 터졌었습니다 뭔가 설계할때 좀더 생각을 했으면 오래걸릴 문제가 아니였는데 그부분이 아쉽습니다.
