### PR TITLE
Week6 서영탁 1600 말이되고픈원숭이 풀이

### DIFF
--- a/src/week6/monkeyWhoWannabeHorse1600/Main.java
+++ b/src/week6/monkeyWhoWannabeHorse1600/Main.java
@@ -1,4 +1,85 @@
 package week6.monkeyWhoWannabeHorse1600;
 
+import java.io.*;
+import java.util.*;
+
 public class Main {
+
+    public static class Pos{
+        int x, y;
+        int count, dist;
+
+        public Pos(int x, int y, int count, int dist) {
+            this.x = x;
+            this.y = y;
+            this.count = count;
+            this.dist = dist;
+        }
+
+    }
+
+    public static int k, n, m;
+    public static int[][] map;
+
+    public static int[] dx = {0, 0, 1, -1, -1, -2, -2, -1, 1, 2, 2, 1};
+    public static int[] dy = {1, -1, 0, 0, -2, -1, 1, 2, -2, -1, 1, 2};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        k = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+        m = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+        for(int i = 0; i < n; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < m; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        System.out.println(bfs());
+    }
+
+    public static int bfs(){
+        boolean[][][] visited = new boolean[n][m][k+1];
+        Queue<Pos> q = new ArrayDeque<>();
+        q.offer(new Pos(0, 0, 0, 0));
+        visited[0][0][0] = true;
+
+        while(!q.isEmpty()){
+            Pos p = q.poll();
+            int x = p.x;
+            int y = p.y;
+            int count = p.count;
+            int dist = p.dist;
+
+            if(x == n-1 && y == m-1) return dist;
+
+            for(int i = 0; i < 12; i++){
+                if(i >= 4 && count >= k) continue;
+
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if(!isRange(nx, ny)) continue;
+                if(map[nx][ny] != 0) continue;
+                int newCount = i >= 4 ? count+1 : count;
+                if(visited[nx][ny][newCount]) continue;
+
+                q.offer(new Pos(nx, ny, newCount, dist+1));
+                visited[nx][ny][newCount] = true;
+            }
+        }
+
+        return -1;
+    }
+
+    public static boolean isRange(int x, int y){
+        return x >= 0 && x < n && y >= 0 && y < m;
+    }
+
 }


### PR DESCRIPTION
## 풀이
이 문제는 일반적인 bfs 탐색에 원숭이가 말처럼 몇 번을 이동했는지를 기록하고 있어야 합니다.
또한, 한 좌표에 대해서 여러번 도착할 수 있습니다. (인접한 칸으로만 이동, 인접한 칸 이동 + 말처럼 이동, 말처럼 이동 * n 등)

Pos class를 만들어 (x, y) 좌표와 몇 번 말처럼 이동했는지(count), 총 몇번 움직였는지(dist)를 저장했습니다.
그리고 나서 방문 처리에 대해서 3차원 배열을 사용했습니다.
`boolean[][][] visited = new boolean[n][m][k+1]`을 사용하여 k+1 자리에 몇 번 말처럼 이동 후 도착하였는지를 처리했습니다.
그 다음 bfs 탐색을 했는데, `int[] dx`, `int[] dy`는 0-3 인덱스는 인접한 칸으로 이동, 4-11 인덱스는 말처럼 이동 입니다.

인접한 칸으로 이동할 때는 count를 증가시키지 않고 현재 count에서 이동할 좌표를 방문했지를 체크했습니다.
말처럼 이동할 때는 count를 1 증가시키고 count+1에서 이동할 좌표에 방문했는지 체크했습니다.

## 리뷰 요청 사항
이해되지 않는 부분이 있다면 리뷰 남겨주세요!

## 느낀점
처음에 [벽 부수고 이동하기 2](https://www.acmicpc.net/problem/14442) 문제와 비슷하다고 생각하여 `visited`배열을 2차원으로 만들고 말 처럼 이동한 횟수를 기록해서 풀려고 했습니다.
하지만 이 문제에서는 말처럼 이동한 칸에도 원숭이처럼 이동해서 도착할 수 있어야 하기 때문에 3차원 배열로 처리하였습니다.