### PR TITLE
Week6 서영탁 11497 통나무건너뛰기 풀이

### DIFF
--- a/src/week6/jumpingLog11497/Main.java
+++ b/src/week6/jumpingLog11497/Main.java
@@ -1,4 +1,49 @@
 package week6.jumpingLog11497;
 
+import java.io.*;
+import java.util.*;
+
 public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int t = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        while(t-->0){
+            int ans = 0;
+
+            int n = Integer.parseInt(br.readLine());
+            int[] arr = new int[n];
+
+            st = new StringTokenizer(br.readLine());
+            for(int i = 0; i < n; i++){
+                arr[i] = Integer.parseInt(st.nextToken());
+            }
+
+            Arrays.sort(arr);
+
+            int pre = 0;
+            for(int i = 2; i < n; i+=2){
+                ans = Math.max(ans, Math.abs(arr[pre] - arr[i]));
+                pre = i;
+            }
+
+            int end = n-1;
+            if(n % 2 == 1) end = n-2;
+            for(int i = end; i > 0; i-=2){
+                ans = Math.max(ans, Math.abs(arr[pre] - arr[i]));
+                pre = i;
+            }
+
+            ans = Math.max(ans, Math.abs(arr[pre] - arr[0]));
+
+            sb.append(ans).append("\n");
+        }
+
+        System.out.println(sb.toString());
+    }
+
 }


### PR DESCRIPTION
## 풀이
처음에는 모든 경우의 수를 조합으로 완전탐색을 해야하나 생각했지만, n이 10,000이라 안되겠다고 생각하였습니다.
따라서, 그리디로 풀어볼 생각을 했고, 다음 그림과 같이 통나무 높이를 세우면 각 통나무의 차이가 가장 작겠다고 생각했습니다.
<img width="343" alt="image" src="https://user-images.githubusercontent.com/89503136/189514889-c3209223-4d2d-4b16-a7b8-fe9a0210b130.png">

먼저 입력으로 주어진 배열을 정렬한 후 한 칸씩 건너뛰면서 통나무 차이의 최댓값을 구했습니다. (0, 2, 4, ... n-2 , n)
그 다음 맨 뒤에서부터 다시 앞으로 한 칸씩 건너뛰면서 통나무 차이의 최댓값을 구했습니다. (n-1, n-3, ... 3, 1)
마지막으로 통나무가 원형으로 세워져 있기 때문에 첫 번째 통나무와 마지막 통나무의 차이도 구했습니다.

맨뒤에서부터 내려올 때 통나무의 개수가 짝수이면 n-1 인덱스부터, 홀수라면 n-2 인덱스부터 시작하여 내려왔습니다.

## 리뷰 요청 사항
이해되지 않는 부분이 있다면 리뷰 남겨주세요!