### PR TITLE
Week6 김수빈 11497 통나무 건너뛰기 풀이

### DIFF
--- a/src/week6/jumpingLog11497/Main.java
+++ b/src/week6/jumpingLog11497/Main.java
@@ -1,4 +1,72 @@
 package week6.jumpingLog11497;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+/**
+ * 통나무로 만들 수 있는 최소 난이도 
+ * 난이도 : 인접한 두 통나물 간의 높이의 차의 최댓값 
+ * 통나무 높이 입력 받은 배열을  양쪽 끝(왼쪽부터 오른쪽) 높이가 가장 작은 순으로  넣는다면 ?
+ * 2     
+ * 2       4
+ * 2 5     4
+ * 2 5   7 4
+ * 2 5 9 7 4
+ * - 1.입력받은 배열 정렬  2 4 5 7 9
+ * - 2. 인덱스 홀수번째값은 오른쪽 끝 , 아닌 것들은 왼쪽 끝에 들어가겠지 ?
+ * 인접한 값들끼리 빼주고 그 값 비교해서 최댓값 찾으면 그게 바로 최소 난이도 
+ * */
 public class Main {
+	static int logNum;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		int T = Integer.parseInt(br.readLine().trim());
+		for(int tc=1;tc<=T;tc++) {
+			logNum = Integer.parseInt(br.readLine().trim());
+			
+			int[] logHeight = new int[logNum]; // 통나무 높이 저장할 리스트
+			st = new StringTokenizer(br.readLine());
+			for(int i=0;i<logNum;i++) {
+				logHeight[i]=Integer.parseInt(st.nextToken());
+			}
+			
+			//배열 정렬(오름차순)
+			Arrays.sort(logHeight);
+			
+			// 정렬된 값 저장될 배열 
+			int[] log = new int[logNum];
+			int left =0;
+			int right =logNum-1;
+			// 배열의 인덱스 홀수번째 값 : 오른쪽 끝, 짝수번째 값 : 왼쪽 끝 ㄱ
+			for(int idx =0;idx<logNum;idx++) {
+				if(idx%2!=0) { // 홀수번째 인덱스
+					log[right]=logHeight[idx];
+					right-=1;
+				}else { // 짝수번째 인덱스
+					log[left]=logHeight[idx];
+					left+=1;
+				}
+			}
+//			System.out.println(Arrays.toString(log));
+
+			
+			// 배열의 맨 앞과 끝 빼주는 것도 잊지 않기 ~! 
+			int min = Math.abs(log[0]-log[logNum-1]);
+			// 인접한 값끼리 빼주기 , 빼주면서 비교는?
+			for(int i=0;i<logNum-1;i++) {
+				min = Math.max(min, Math.abs(log[i]-log[i+1]));
+
+			}
+
+			System.out.println(min);
+		}
+
+	}
+	
 }


### PR DESCRIPTION
## 풀이
* 문제를 처음 접근할떄 순열을 배열로 저장해서 값을 비교하는 방법으로 접근했습니다. 순열을 구현하는 중 수가 늘어날수록 구해야하는 순열의 개수또한 늘어나고 통나무의 개수가 최대 100,000이기에 새로운 방법을 찾아 설명을 차분히 보니,  통나무 높이 입력 받은 배열을  양쪽 끝(왼쪽부터 오른쪽) 높이가 가장 작은 순 정렬하면 "인접한 두 통나무간의 높이 차" 최소값으로 이루어진다는 것을 활용하여 
* 입력 배열 오름차순으로 정렬 
*  배열의 인덱스 홀수번째 값은 오른쪽 끝, 짝수번째는 왼쪽 끝으로 정렬
* 인접한 값끼리 빼주며 그 값을 비교하여 최댓값을 찾으면 그게 바로 문제에서 구하는 최소 난이도 !!
* 인접한 값을 빼줄 때 배열의 맨 처음 값과 맨 끝값의 차 또한 포함 !! 
## 리뷰 요청 사항
* 
## 느낀점 😖 
* 순서에 관련이 있다고해서 냅다 순열로 접근하는 것보단, 배열에 대한 규칙이 있는지 먼저 파악하고 문제를 풀어봐야겠다고 느꼈습니다. 