### PR TITLE
week6 김명진 1600 말이되고픈 원숭이 풀이

### DIFF
--- a/src/week6/monkeyWhoWannabeHorse1600/Main.java
+++ b/src/week6/monkeyWhoWannabeHorse1600/Main.java
@@ -1,4 +1,99 @@
 package week6.monkeyWhoWannabeHorse1600;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+
+class Monkey {
+    int row;
+    int col;
+    int depth;
+    int remainHorseMode;
+
+
+    public Monkey(int row, int col, int depth, int remainHorseMode) {
+        this.row = row;
+        this.col = col;
+        this.depth = depth;
+        this.remainHorseMode = remainHorseMode;
+    }
+
+}
+
 public class Main {
+    static int K;
+    static int W, H;
+    static boolean[][][] visited;
+    static int[][] horseModeAlpha = new int[][]{{-1, 2}, {1, 2}, {2, 1}, {2, -1}, {1, -2}, {-1, -2}, {-2, -1}, {-2, 1}};
+    static int[][] monkeyAlpha = new int[][]{{0, 1}, {-1, 0}, {0, -1}, {1, 0}};
+
+    public static void main(String[] args) throws IOException {
+        //System.setIn(new FileInputStream("resources/study/week6/BJ1600/input3.txt"));
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        K = Integer.parseInt(bf.readLine());
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        W = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+        visited = new boolean[H][W][K + 1];
+        for (int row = 0; row < H; row++) {
+            st = new StringTokenizer(bf.readLine());
+            for (int col = 0; col < W; col++) {
+                int val = Integer.parseInt(st.nextToken());
+                if (val == 1) {
+                    for (int i = 0; i <= K; i++) {
+                        visited[row][col][i] = true;
+                    }
+                }
+            }
+        }
+        bfs();
+        // bfs로 해결할거다
+        // 단 두가지 (가지)경우에 대해 본다
+        // 1. 말로 이동가능한경우 이동한다 넘길때 horseMode count 내린다;
+        // 2. 원숭이로 이동가능한경우 이동한다 넘길때 horseModeCount 건들지 않는다.
+        System.out.println(-1);
+    }
+
+    public static void bfs() {
+        Queue<Monkey> q = new LinkedList<>();
+        visited[0][0][K] = true;
+        q.add(new Monkey(0, 0, 0, K));
+
+        while (!q.isEmpty()) {
+            Monkey currMonkey = q.poll();
+            if (currMonkey.row == H - 1 && currMonkey.col == W - 1) {
+                System.out.println(currMonkey.depth);
+                System.exit(0);
+            }
+            // 말처럼 이동하는 부분 말처럼 이동하고 이동할수 있는 remainHorseMode 를 하나 내린다.
+            if (currMonkey.remainHorseMode > 0) {
+                for (int dh = 0; dh < 8; dh++) {
+                    int nextRow = currMonkey.row + horseModeAlpha[dh][0];
+                    int nextCol = currMonkey.col + horseModeAlpha[dh][1];
+                    if (isIn(nextRow, nextCol) && !visited[nextRow][nextCol][currMonkey.remainHorseMode - 1]) {
+                        visited[nextRow][nextCol][currMonkey.remainHorseMode - 1] = true;
+                        q.add(new Monkey(nextRow, nextCol, currMonkey.depth + 1, currMonkey.remainHorseMode - 1));
+                    }
+                }
+            }
+
+            for (int mh = 0; mh < 4; mh++) {
+                int nextRow = currMonkey.row + monkeyAlpha[mh][0];
+                int nextCol = currMonkey.col + monkeyAlpha[mh][1];
+                if (isIn(nextRow, nextCol) && !visited[nextRow][nextCol][currMonkey.remainHorseMode]) {
+                    visited[nextRow][nextCol][currMonkey.remainHorseMode] = true;
+                    q.add(new Monkey(nextRow, nextCol, currMonkey.depth + 1, currMonkey.remainHorseMode));
+                }
+            }
+        }
+    }
+
+    public static boolean isIn(int row, int col) {
+        return row < H && row >= 0 && col < W && col >= 0;
+    }
+
 }


### PR DESCRIPTION
## 풀이
* bfs 를 이용한 최단경로 풀이를 활용했습니다.
* 원숭이를 객체로 만들어 queue 에 넣었습니다.
* 원숭이 객체는 `depth` 얼마나 깊게 들어왔는지 (이동한 횟수),
* 이문제의 포인트는 방문처리를 어떻게 하는가 였습니다.
  *  문제에선 언제 말처럼 점프한다는 언급이 없기에 원숭이는 언제 말처럼 점프할지모릅니다(점프하는 시점을 모두 고려)
  *  그렇기에 만약` k = 2` 라면 한번 점프 할때 따로 방문을 관리해야하고(경로를 별도로 관리한다는 의미) 두번째 점프떄는 한번 점프할때 0번 점프할때 경로랑 별도로 관리 해야합니다.
  * 그리고 점프를 하면 이전 점프 방문처리에서 방문한 경우에도 방문이 가능해야합니다. 다음과 같은 경우가 있기 떄문입니다 [#114](https://github.com/ManduTheCat/ssafy_algorithm_study/pull/114#issuecomment-1242968338 )
* 이러한 이유로 3차원 배열을 통해 방문을 관리 해야 했습니다. `visited[row][col][점프횟수]`
## 리뷰 요청 사항
* 87260kb | 536ms 의 공간 | 시간 복잡도를 가진 코드입니다. 뭔가 낭비가 되는 부분? 이 보이시면 말씀해주시면 좋겠습니다.
* 처음에 말처럼 점프하는 시점이 어디가 될지 몰라 dfs 완탐을 만들었는데 시간초과가 났습니다. 이렇게 지도 탐색 형태의 유형에선 dfs 로 전체 경우의 수를 구하면 `O(N*M)`  일까요?

</html>
## 느낀점
* dfs(시간초과) -> 모든 방문배열을 객체에 할당(메모리 초과) -> 3차원 방문배열 전역으로 사용  과정을 통해 통과했습니다. 
정말 쉽지 않았는데 아직도 뭔가 탐색과정이 머리에 그려지지 않아 html js 로 한번 그려보는중입니다. 
*  비슷한 문제 [벽부수고 이동하기2](https://www.acmicpc.net/problem/14442) 풀어봤는데 복습한는데 도움이 많이 된거 같습니다