### PR TITLE
Week9 서영탁 SWEA 1949 등산로조성 풀이

### DIFF
--- a/src/week9/makingTrailSWEA1949/Main.java
+++ b/src/week9/makingTrailSWEA1949/Main.java
@@ -1,4 +1,0 @@
-package week9.makingTrailSWEA1949;
-
-public class Main {
-}

--- a/src/week9/makingTrailSWEA1949/Solution.java
+++ b/src/week9/makingTrailSWEA1949/Solution.java
@@ -1,0 +1,111 @@
+package week9.makingTrailSWEA1949;
+
+import java.io.*;
+import java.util.*;
+
+public class Solution {
+
+    public static class Pos{
+        int x, y;
+        int rest;  // 산을 깍을 수 있나 없나. 1 : 깍을 수 있음, 0 : 깍을 수 없음.
+        int dist;  // 이동한 거리
+
+        public Pos(int x, int y, int rest, int dist) {
+            this.x = x;
+            this.y = y;
+            this.rest = rest;
+            this.dist = dist;
+        }
+    }
+
+    public static int n, k, ans;
+    public static int[][] map;
+    public static boolean[][] visited;
+
+    public static int[] dx = {0, 0, 1, -1};
+    public static int[] dy = {1, -1, 0, 0};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int t = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        for (int tc = 1; tc <= t; tc++) {
+            ans = 0;
+
+            st = new StringTokenizer(br.readLine());
+            n = Integer.parseInt(st.nextToken());
+            k = Integer.parseInt(st.nextToken());
+
+            int max = 0;  // 가장 높은 봉우리 높이
+            map = new int[n][n];
+            for(int i = 0; i < n; i++){
+                st = new StringTokenizer(br.readLine());
+                for(int j = 0; j < n; j++){
+                    map[i][j] = Integer.parseInt(st.nextToken());
+                    max = Math.max(max, map[i][j]);  // 가장 높은 봉우리 높이 저장
+                }
+            }
+
+            visited = new boolean[n][n];
+            for(int i = 0; i < n; i++){
+                for(int j = 0; j < n; j++){
+                    if(map[i][j] == max){  // 가장 높은 봉우리라면 dfs로 탐색해본다.
+                        visited[i][j] = true;
+                        dfs(new Pos(i, j, 1, 1));
+                        visited[i][j] = false;
+                    }
+                }
+            }
+
+            sb.append("#").append(tc).append(" ").append(ans).append("\n");
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    public static void dfs(Pos pos){
+        ans = Math.max(ans, pos.dist);  // 매번 최장 거리 갱신
+
+        int x = pos.x;
+        int y = pos.y;
+        int rest = pos.rest;
+        int dist = pos.dist;
+
+        for(int i = 0; i < 4; i++){  // 4방 탐색
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if(!isRange(nx, ny)) continue;
+
+            if(!visited[nx][ny]){
+                if(map[x][y] > map[nx][ny]) {  // 산을 깍지 않고 갈 수 있다면, rest가 1이든 0이든 갈 수 있음
+                    visited[nx][ny] = true;
+                    dfs(new Pos(nx, ny, rest, dist+1));
+                    visited[nx][ny] = false;
+                }
+                else{  // 산을 깍아야지만 갈 수 있다면
+                    if(rest == 0) continue;  // 산을 이미 깍아서 rest == 0이라면 못감. 패스
+
+                    if(map[x][y] > map[nx][ny] - k){  // k를 깍아서 갈 수 있다면
+                        visited[nx][ny] = true;
+                        int tmp = map[nx][ny];
+                        map[nx][ny] = map[x][y] - 1;  // k만큼 다 깍을 필요가 없음. map[x][y]보다 1 작게만 깍음.
+
+                        dfs(new Pos(nx, ny, 0, dist+1));
+
+                        map[nx][ny] = tmp;  // 원상 복구
+                        visited[nx][ny] = false;
+                    }
+                }
+            }
+        }
+    }
+
+    public static boolean isRange(int x, int y){
+        return x >= 0 && x < n && y >= 0 && y < n;
+    }
+
+}


### PR DESCRIPTION
## 풀이
등산로는 가장 높은 봉우리에서 시작하여 등산로의 높이가 이전 위치보다 낮은 곳으로만 내려갈 수 있습니다.
하자만, 내려가는 길에 딱 한 곳을 정해서 최대 K 깊이만큼 지형을 깍을 수 있는데, 이러한 규칙을 따르면서 등산로의 최장 거리를 찾는 문제입니다.

우선 입력을 받으면서 가장 높은 봉우리의 높이를 구했고, 그 봉우리에서부터 dfs로 내려갈 수 있는 등산로의 길이를 구했습니다.
dfs에서 4방 탐색을 통해 아직 방문하지 않은 위치에 대해 산을 깍지 않고 갈 수 있는 위치는 그냥 이동해주었습니다.
산을 깍아야지만 이동할 수 있는 위치에 대해서 처리가 중요한데, 
이 위치까지 오기 전에 이미 깍아서 `rest`가 0이라면 더 이상 이동할 수 없습니다. 
아직 깍을 수 있다면, 다음 위치의 높이에서 K만큼 깍아보고 이 높이가 현재 위치보다 낮아 갈 수 있게 된다면 이동하게 했습니다.
그런데 여기서 K만큼 전부 깍을 필요없이, 현재 위치보다 1만 작게 깍아야 이 후의 다른 위치로 이동할 수 있을 확률이 높아지니 1만 작게 깍았습니다.


## 리뷰 요청 사항
궁금한 점이나 더 좋은 방법이 있다면 리뷰 남겨주세요.

## 느낀점
벽 부수고 이동하기나, 말이 되고픈 원숭이와 비슷한 문제라고 생각했는데, 이 문제는 최장 거리를 구해야 한다는 것이 달랐습니다.